### PR TITLE
Check only external links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
 
 script:
   - gulp preview:build bundle:pack
-  - link-checker public --http-redirects=1 --url-ignore='/6.0/index.html' --url-ignore='^#$'
+  - link-checker public --http-redirects=1 --external-only
 
 cache:
   yarn: true


### PR DESCRIPTION
Because it will be common to have broken xref links in the example content, it only makes sense to check links that go to external URLs.

This should fix the broken build on `master`.