### PR TITLE
Update header and footer links

### DIFF
--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -2,9 +2,9 @@
 	<nav>
 		<section>
 			<h3>Documentation</h3>
-			<h4><a href="https://developer.lightbend.com/docs/lightbend-platform/2.0/">Lightbend Platform</a></h4>
+			<h4><a href="https://developer.lightbend.com/docs/lightbend-platform/introduction/">Lightbend Platform</a></h4>
 			<ul>
-				<li><a href="https://developer.lightbend.com/docs/lightbend-platform/2.0/">Lightbend Platform Guide</a></li>
+				<li><a href="https://developer.lightbend.com/docs/lightbend-platform/introduction/">Lightbend Platform Guide</a></li>
 				<li><a href="https://developer.lightbend.com/docs/pipelines/current/">Pipelines</a></li>
 				<li><a href="https://developer.lightbend.com/docs/telemetry/current/home.html">Telemetry</a></li>
 				<li><a href="https://developer.lightbend.com/docs/console/current/">Console</a></li>
@@ -46,7 +46,7 @@
 
 	<div class="legal-social">
 		<div class="legal">
-			<p>© Lightbend 2019 | <a href="https://www.lightbend.com/legal/licenses">Licenses</a> | <a href="https://www.lightbend.com/legal/terms">Terms</a> | <a href="https://www.lightbend.com/legal/privacy">Privacy Policy</a> | <a href="https://www.lightbend.com/legal/cookie">Cookie Listing</a> | <a class="optanon-toggle-display">Cookie Settings</a> 
+			<p>© Lightbend 2019 | <a href="https://www.lightbend.com/legal/licenses">Licenses</a> | <a href="https://www.lightbend.com/legal/terms">Terms</a> | <a href="https://www.lightbend.com/legal/privacy">Privacy Policy</a> | <a href="https://www.lightbend.com/legal/cookie">Cookie Listing</a> | <a class="optanon-toggle-display">Cookie Settings</a>
 			<span class="footer-logo">
 				<svg class="lightbend-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 372 80">
 					<title>lightbend-logo</title>

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -14,10 +14,10 @@
         <div class="navbar-item has-dropdown is-hoverable">
           <span class="navbar-link">Documentation</span>
           <div class="navbar-dropdown">
-            <a class="navbar-item section-title" href="https://developer.lightbend.com/docs/lightbend-platform/2.0/">Lightbend Platform</a>
+            <a class="navbar-item section-title" href="https://developer.lightbend.com/docs/lightbend-platform/introduction/">Lightbend Platform</a>
             <div class="columns">
               <div class="navbar-dropdown-col mm-col-two">
-                <a class="navbar-item" href="https://developer.lightbend.com/docs/lightbend-platform/2.0/">Lightbend Platform Guide</a>
+                <a class="navbar-item" href="https://developer.lightbend.com/docs/lightbend-platform/introduction/">Lightbend Platform Guide</a>
                 <a class="navbar-item" href="https://developer.lightbend.com/docs/pipelines/current/">Pipelines</a>
                 <a class="navbar-item" href="https://developer.lightbend.com/docs/telemetry/current/home.html">Telemetry</a>
                 <a class="navbar-item" href="https://developer.lightbend.com/docs/console/current/">Console</a>


### PR DESCRIPTION
These point to the new canonical URL for the Lightbend Platform guide.
The previous URL redirects.