### PR TITLE
Add image groups, fix sticky sidebar, fix firefox bold fonts

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -14,25 +14,26 @@ Author Name
 :page-supergroup-mac-ubuntu: OS
 
 
-== Cu solet
 
-[.tabset] 
-Scala::
-This is the scala of the first tab.
-Java::
-+
-[source,java]
-----
-public class Minikube {
-  private String name;
-  public Person(String name) {
-    this.name = name;
-  }
-}
-----
 
 == Formatted Text
 See: https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#formatted-text[window=_blank]
+
+----
+bold *constrained* & **un**constrained
+
+italic _constrained_ & __un__constrained
+
+bold italic *_constrained_* & **__un__**constrained
+
+monospace `constrained` & ``un``constrained
+
+monospace bold `*constrained*` & ``**un**``constrained
+
+monospace italic `_constrained_` & ``__un__``constrained
+
+monospace bold italic `*_constrained_*` & ``**__un__**``constrained
+----
 
 bold *constrained* & **un**constrained
 
@@ -50,10 +51,153 @@ monospace bold italic `*_constrained_*` & ``**__un__**``constrained
 
 
 == Images
+
+----
+image::https://d3gnpvjw8j16uq.cloudfront.net/assets/images/svg/diagrams/lightbend-platform-overview.svg[Lightbend Platform Overview]
+----
+
 image::https://d3gnpvjw8j16uq.cloudfront.net/assets/images/svg/diagrams/lightbend-platform-overview.svg[Lightbend Platform Overview]
 
 
+== Block Image Groups
+
+=== Basic example
+Images are vertically centered by default. Images will proportionately take up horizontal space based on their natural widths. On small screens the images will resort back to stacking in a column down the page.
+
+----
+[.image-group]
+--
+image::https://via.placeholder.com/600x150[]
+image::https://via.placeholder.com/300x500[]
+image::https://via.placeholder.com/500x300[]
+--
+----
+
+[.image-group]
+--
+image::https://via.placeholder.com/600x150?text=Example+Image[]
+image::https://via.placeholder.com/300x500?text=Example+Image[]
+image::https://via.placeholder.com/500x300?text=Example+Image[]
+--
+
+{empty} +
+
+=== Vertically align to top
+
+  
+----
+[.image-group.top]
+--
+image::https://via.placeholder.com/300x300[]
+image::https://via.placeholder.com/300x600[]
+image::https://via.placeholder.com/300x400[]
+image::https://via.placeholder.com/300x600[]
+image::https://via.placeholder.com/300x300[]
+image::https://via.placeholder.com/300x200[]
+--
+----
+
+[.image-group.top]
+--
+image::https://via.placeholder.com/300x300?text=Example+Image[]
+image::https://via.placeholder.com/300x600?text=Example+Image[]
+image::https://via.placeholder.com/300x400?text=Example+Image[]
+image::https://via.placeholder.com/300x600?text=Example+Image[]
+image::https://via.placeholder.com/300x300?text=Example+Image[]
+image::https://via.placeholder.com/300x200?text=Example+Image[]
+--
+
+{empty} +
+
+=== Vertically align to bottom
+
+----
+[.image-group.bottom]
+--
+image::https://via.placeholder.com/600x150[]
+image::https://via.placeholder.com/300x500[]
+image::https://via.placeholder.com/500x300[]
+--
+----
+
+[.image-group.bottom]
+--
+image::https://via.placeholder.com/600x150?text=Example+Image[]
+image::https://via.placeholder.com/300x500?text=Example+Image[]
+image::https://via.placeholder.com/500x300?text=Example+Image[]
+--
+
+{empty} +
+
+=== Custom Widths
+
+----
+[.image-group]
+--
+[.width-25]
+image::https://via.placeholder.com/600x300[]
+[.width-50]
+image::https://via.placeholder.com/600x300[]
+[.width-25]
+image::https://via.placeholder.com/600x300[]
+--
+----
+
+[.image-group]
+--
+[.width-25]
+image::https://via.placeholder.com/600x300?text=25%+Width[]
+[.width-50]
+image::https://via.placeholder.com/600x300?text=50%+Width[]
+[.width-25]
+image::https://via.placeholder.com/600x300?text=25%+Width[]
+--
+
+{empty} +
+
+You can use the following widths
+----
+[.width-5] 
+[.width-10] 
+[.width-15] 
+[.width-20] 
+[.width-25] 
+[.width-30] 
+[.width-35] 
+[.width-40] 
+[.width-45] 
+[.width-50] 
+[.width-55] 
+[.width-60] 
+[.width-65] 
+[.width-70] 
+[.width-75] 
+[.width-80] 
+[.width-85] 
+[.width-90] 
+[.width-95] 
+[.width-100]
+----
+
+
 == Tabsets
+
+[.tabset] 
+Scala::
+This is the scala of the first tab.
+Java::
++
+[source,java]
+----
+public class Minikube {
+  private String name;
+  public Person(String name) {
+    this.name = name;
+  }
+}
+----
+
+
 [.tabset] 
 Play::
 + 
@@ -538,50 +682,6 @@ If you installed the CLI and the default site generator globally, you can upgrad
  $ npm i -g @antora/cli @antora/site-generator-default
 ====
 
-Nominavi luptatum eos, an vim hinc philosophia intellegebat.
-Eu mea inani iriure.
-
-[discrete]
-== Voluptua singulis
-
-Cum dicat putant ne.
-Est in reque homero principes, meis deleniti mediocrem ad has.
-Altera atomorum his ex, has cu elitr melius propriae.
-Eos suscipit scaevola at.
-
-
-== Cavern Glow
-
-The river rages through the cavern, rattling its content...
-
-If you installed the CLI and the default site generator globally, you can upgrade both of them with the same command.
-
-If you installed the CLI and the default site generator globally, you can upgrade both of them with the same command.
-
-If you installed the CLI and the default site generator globally, you can upgrade both of them with the same command.
-
-If you installed the CLI and the default site generator globally, you can upgrade both of them with the same command.
-
-If you installed the CLI and the default site generator globally, you can upgrade both of them with the same command.
-
-If you installed the CLI and the default site generator globally, you can upgrade both of them with the same command.
-
-If you installed the CLI and the default site generator globally, you can upgrade both of them with the same command.
-
-
-Crawling through the twisted understory...
-
-== The Ravages of Writing
-
-Her finger socks had been vaporized by crystalline nuggets of...
-
-
-
-Two fresh Burdockian leaves, harvested by the light of the teal moons...
-
-
-
-Crawling through the twisted understory...
 
 
 Crawling through the twisted understory...

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -49,6 +49,7 @@ body {
   -webkit-font-smoothing: antialiased;
   font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 a {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -293,6 +293,58 @@ tbody tr:nth-child(odd) {
   max-width: 100%;
 }
 
+@media screen and (min-width: 500px) {
+
+  .doc .image-group .content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .doc .image-group.top .content {
+    align-items: flex-start;
+  }
+
+  .doc .image-group.bottom .content {
+    align-items: flex-end;
+  }
+
+  .doc .image-group .content .imageblock {
+    padding: 0 .5rem;
+  }
+  .doc .image-group .content .imageblock:first-child {
+    padding-left: 0;
+  }
+  .doc .image-group .content .imageblock:last-child {
+    padding-right: 0;
+  }
+
+  .doc .image-group .content .imageblock.width-5 {width: 5%;}
+  .doc .image-group .content .imageblock.width-10 {width: 10%;}
+  .doc .image-group .content .imageblock.width-15 {width: 15%;}
+  .doc .image-group .content .imageblock.width-20 {width: 20%;}
+  .doc .image-group .content .imageblock.width-25 {width: 25%;}
+  .doc .image-group .content .imageblock.width-30 {width: 30%;}
+  .doc .image-group .content .imageblock.width-35 {width: 35%;}
+  .doc .image-group .content .imageblock.width-40 {width: 40%;}
+  .doc .image-group .content .imageblock.width-45 {width: 45%;}
+  .doc .image-group .content .imageblock.width-50 {width: 50%;}
+  .doc .image-group .content .imageblock.width-55 {width: 55%;}
+  .doc .image-group .content .imageblock.width-60 {width: 60%;}
+  .doc .image-group .content .imageblock.width-65 {width: 65%;}
+  .doc .image-group .content .imageblock.width-70 {width: 70%;}
+  .doc .image-group .content .imageblock.width-75 {width: 75%;}
+  .doc .image-group .content .imageblock.width-80 {width: 80%;}
+  .doc .image-group .content .imageblock.width-85 {width: 85%;}
+  .doc .image-group .content .imageblock.width-90 {width: 90%;}
+  .doc .image-group .content .imageblock.width-95 {width: 95%;}
+  .doc .image-group .content .imageblock.width-100 {width: 100%;}
+
+}
+
+
+
+
 .doc > h1 {
   font-size: 2rem;
   margin: 2rem 0 1.5rem;

--- a/src/css/toc.css
+++ b/src/css/toc.css
@@ -13,12 +13,16 @@
 		max-width: 340px;
 	}
 	.toc-menu {
-		position: sticky;
-		top: 150px;
 		display: inline-block;
 		padding: 0 1rem;
 		border: 0px solid grey;
 		max-width: 600px;
+		margin-top: 20px;
+	}
+	.toc-menu.stick {
+		position: sticky;
+		top: 150px;
+		margin-top: 0;
 	}
 	#toc {
 		display: none;

--- a/src/js/05-on-this-page.js
+++ b/src/js/05-on-this-page.js
@@ -42,6 +42,13 @@
   menu.appendChild(title)
   menu.appendChild(list)
 
+  //should it stick
+  var intViewportHeight = window.innerHeight
+  var menuHeight = menu.offsetHeight
+  if(menuHeight < intViewportHeight){
+    menu.classList.add("stick")
+  }
+
   if (sidebar) {
     window.addEventListener('load', function () {
       onScroll()


### PR DESCRIPTION
@rstento this adds image blocks for you. Fire up the UI theme locally as I've placed documented examples in the UI theme for you to look at. Screen shot below as well. 

Also I've updated the 'On This Page' sidebar so that it doesn't stick when the content of the sidebar is taller than the browser viewport. Lastly I've improved font rendering for Firefox mac.

![screenshot-localhost-5252-2019 08 08-16-04-25](https://user-images.githubusercontent.com/1418129/62743364-101e6980-b9f7-11e9-9b1a-42cc6a145937.png)


